### PR TITLE
Fix middleware tests

### DIFF
--- a/lib/account_middleware.rb
+++ b/lib/account_middleware.rb
@@ -5,8 +5,8 @@ class AccountMiddleware
 
   # http://example.com/12345/projects
   def call(env)
-    request = ActionDispatch::Request.new env
-    _, account_id, request_path = request.path.split('/', 3)
+    original_request_path = [env["SCRIPT_NAME"], env["PATH_INFO"]].join
+    _, account_id, request_path = original_request_path.split('/', 3)
 
     if account_id =~ /\d+/
       if account = Account.find_by(id: account_id)
@@ -15,10 +15,12 @@ class AccountMiddleware
         return [302, { "Location" => "/" }, []]
       end
 
-      request.script_name  = "/#{account_id}"
-      request.path_info    = "/#{request_path}"
+      env["SCRIPT_NAME"]  = "/#{account_id}"
+      env["PATH_INFO"]    = "/#{request_path}"
+      env["REQUEST_PATH"] = "/#{request_path}"
+      env["REQUEST_URI"]  = "/#{request_path}"
     end
 
-    @app.call(request.env)
+    @app.call(env)
   end
 end


### PR DESCRIPTION
Hey @excid3,
while this [pull request](https://github.com/gorails-screencasts/gorails-episode-234/pull/2/files) fixed integration tests, it broke the middleware tests.
I could have kept the `ActionDispatch::Request` introduced by the previous pull request but:
* introducing a Rails class in this piece of middleware felt wrong
* it would require a patch mixing `request.env.variable = ` and `request.env["VARIABLE"] = ` which felt inelegant.
* it seems unnecessary (I took the join idea from the way the rack webrick handlers handles it)

We could probably use `env["PATH_INFO"]` instead of the `[env["SCRIPT_NAME"], env["PATH_INFO"]].join` but in the off chance that another piece of middleware modifies `SCRIPT_NAME`, this seemed preferable.

I'm new to all of this, so I might be missing (or misunderstanding) something.

Also I don't know about REQUEST_PATH but I found that REQUEST_URI seems only provided by some application servers. I guess you hinted at that in the video, this left me wondering if there's a way to easily discover if a new variable must be added in the future.